### PR TITLE
Use apply_async and provide countdown for send_after

### DIFF
--- a/dbmail/__init__.py
+++ b/dbmail/__init__.py
@@ -55,12 +55,10 @@ def db_sender(slug, recipient, *args, **kwargs):
 
         if send_at_date is not None and isinstance(send_at_date, datetime):
             kwargs.update({'eta': send_at_date})
-        if send_after is not None:
-            kwargs.update({'countdown': send_after})
         if expiry is not None:
             kwargs.update({'expires': expiry})
         if template.is_active:
-            return dbmail.tasks.db_sender.delay(*args, **kwargs)
+            return dbmail.tasks.db_sender.apply_async(args, kwargs, countdown=send_after)
     else:
         module = import_module(backend)
         if DEBUG is True:


### PR DESCRIPTION

db_sender should not use delay, but instead use apply_async
```
So delay is clearly convenient, but if you want to set additional execution options you have to use apply_async.
```
The `send_after` parameter should map to `countdown` and this should be an argument to `apply_async`, not a `kwarg`
