### PR TITLE
Add DEFAULT_LANG setting and improve README to correctly use the tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,33 @@ Installation
 3. Sync database (``./manage.py migrate``).
 
 
+Development
+-----------
+
+1. Testing using Docker:
+
+.. code-block:: bash
+
+   $ docker build -t dbmail .
+   $ docker run -it -d -p 8000:8000 --name dbmail dbmail
+   $ docker exec -i -t dbmail /bin/bash
+
+After you get into the docker instance:
+
+.. code-block:: bash
+
+    pip3 install -r requirements/tests.txt
+    python3 demo/manage.py test dbmail
+
+2. Testing locally:
+
+.. code-block:: bash
+
+    pip3 install -r requirements/tests.txt
+    python3 setup.py install
+    python3 demo/manage.py test dbmail
+
+
 Mail API
 --------
 

--- a/dbmail/defaults.py
+++ b/dbmail/defaults.py
@@ -144,3 +144,4 @@ APNS_GW_HOST = get_settings('DB_APNS_GW_HOST', 'gateway.push.apple.com')
 UPDATE_ON_DUPLICATE_REG_ID = get_settings('DB_UPDATE_ON_DUPLICATE_REG_ID', True)
 
 DEBUG = settings.DEBUG and get_settings('DB_MAILER_DEBUG', False)
+DEFAULT_LANG = get_settings('DB_MAILER_DEFAULT_LANG', 'en')

--- a/dbmail/defaults.py
+++ b/dbmail/defaults.py
@@ -144,4 +144,4 @@ APNS_GW_HOST = get_settings('DB_APNS_GW_HOST', 'gateway.push.apple.com')
 UPDATE_ON_DUPLICATE_REG_ID = get_settings('DB_UPDATE_ON_DUPLICATE_REG_ID', True)
 
 DEBUG = settings.DEBUG and get_settings('DB_MAILER_DEBUG', False)
-DEFAULT_LANG = get_settings('DB_MAILER_DEFAULT_LANG', 'en')
+TEMPLATES_DEFAULT_LANG = get_settings('DB_MAILER_TEMPLATES_DEFAULT_LANG', 'en')

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -20,7 +20,8 @@ from dbmail.defaults import (
     PRIORITY_STEPS, UPLOAD_TO, DEFAULT_CATEGORY, AUTH_USER_MODEL,
     DEFAULT_FROM_EMAIL, DEFAULT_PRIORITY, CACHE_TTL,
     BACKEND, _BACKEND, BACKENDS_MODEL_CHOICES, MODEL_HTMLFIELD,
-    MODEL_SUBSCRIPTION_DATA_FIELD, SORTED_BACKEND_CHOICES
+    MODEL_SUBSCRIPTION_DATA_FIELD, SORTED_BACKEND_CHOICES,
+    DEFAULT_LANG,
 )
 from dbmail.lang_choices import LANGUAGES as LANG_CHOICES
 
@@ -256,8 +257,7 @@ class MailTemplate(models.Model):
         try:
             localized_content = mail_template.localizations.get(lang=lang)
         except MailTemplateLocalizedContent.DoesNotExist:
-            if lang != 'en':
-                logger.error('Localized template not found for lang={}, slug={}'.format(lang, mail_template.slug))
+            logger.error('Localized template not found for lang={}, slug={}'.format(lang, mail_template.slug))
             return
 
         setattr(mail_template, 'subject', localized_content.subject)
@@ -283,7 +283,7 @@ class MailTemplate(models.Model):
         setattr(obj, 'files_list', files_list)
         setattr(obj, 'auth_credentials', auth_credentials)
 
-        if lang:
+        if lang and lang != DEFAULT_LANG:
             cls.localize_template(obj, lang)
 
         cache.set(cache_key, obj, timeout=CACHE_TTL, version=1)

--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -21,7 +21,7 @@ from dbmail.defaults import (
     DEFAULT_FROM_EMAIL, DEFAULT_PRIORITY, CACHE_TTL,
     BACKEND, _BACKEND, BACKENDS_MODEL_CHOICES, MODEL_HTMLFIELD,
     MODEL_SUBSCRIPTION_DATA_FIELD, SORTED_BACKEND_CHOICES,
-    DEFAULT_LANG,
+    TEMPLATES_DEFAULT_LANG,
 )
 from dbmail.lang_choices import LANGUAGES as LANG_CHOICES
 
@@ -283,7 +283,7 @@ class MailTemplate(models.Model):
         setattr(obj, 'files_list', files_list)
         setattr(obj, 'auth_credentials', auth_credentials)
 
-        if lang and lang != DEFAULT_LANG:
+        if lang and lang != TEMPLATES_DEFAULT_LANG:
             cls.localize_template(obj, lang)
 
         cache.set(cache_key, obj, timeout=CACHE_TTL, version=1)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,4 @@ flake8>=2.4.1
 coverage==3.7.1
 coveralls==0.3
 django-tinymce>=1.5.3
+mock==2.0.0


### PR DESCRIPTION
### What does this do

Adds a `DEFAULT_LANG` inside django-db-mailer (also exposed as a django setting called `DB_MAILER_DEFAULT_LANG`) that represents the `lang` in which the base MailTemplates are defined, and when `get_template` it's called with `lang == DEFAULT_LANG` it will return that MailTemplate without trying to localize the content.
### Why are we doing this

[PLAT-311](https://datamindedsolutions.atlassian.net/browse/PLAT-311)