### PR TITLE
Change _get_message and _get_message_with_base to also allow the use

### DIFF
--- a/dbmail/backends/mail.py
+++ b/dbmail/backends/mail.py
@@ -50,7 +50,8 @@ class Sender(object):
         self._context = self._get_context(args)
 
         self._subject = self._get_subject()
-        self._message = self._get_message()
+        base_template = kwargs.pop('base_template', self._template.base)
+        self._message = self._get_message(base_template=base_template)
         self._files = kwargs.pop('files', [])
         self._kwargs = kwargs
         self._num = 1
@@ -129,11 +130,11 @@ class Sender(object):
         return self._render_template(
             self._get_str_by_language('subject'), self._context)
 
-    def _get_message_with_base(self):
+    def _get_message_with_base(self, base_template):
         self._context['content'] = self._render_template(
             self._get_str_by_language('message'), self._context)
         return self._render_template(
-            self._get_str_by_language('message', self._template.base),
+            self._get_str_by_language('message', base_template),
             self._context
         )
 
@@ -141,9 +142,9 @@ class Sender(object):
         return self._render_template(
             self._get_str_by_language('message'), self._context)
 
-    def _get_message(self):
-        if self._template.base:
-            return self._get_message_with_base()
+    def _get_message(self, base_template=None):
+        if base_template:
+            return self._get_message_with_base(base_template)
         return self._get_standard_message()
 
     def _get_msg_with_track(self):

--- a/dbmail/tests/base.py
+++ b/dbmail/tests/base.py
@@ -4,7 +4,7 @@ from django.core.cache import cache
 from django.test import TestCase
 
 from dbmail.models import (
-    MailTemplate, MailTemplateLocalizedContent,
+    MailTemplate, MailBaseTemplate, MailTemplateLocalizedContent,
 )
 
 
@@ -12,6 +12,36 @@ class BaseTestCase(TestCase):
 
     def tearDown(self):
         cache.clear()
+
+    def _create_base_template(self):
+        return MailBaseTemplate.objects.create(
+            name="Test Base Template",
+            message="Test Base Template"
+        )
+
+    def _create_template_with_base(self):
+        base_template = MailBaseTemplate.objects.create(
+            name="Localized Base Template",
+            message="Base Template: {{content}}"
+        )
+        return MailTemplate.objects.create(
+            name="Site welcome template wit base",
+            subject="Welcome",
+            message="Welcome to our site. We are glad to see you.",
+            slug="welcome_with_base",
+            is_html=False,
+            id=2,
+            base=base_template,
+        )
+
+    def _create_localized_template_with_base(self):
+        template = self._create_template_with_base()
+        return MailTemplateLocalizedContent.objects.create(
+            template=template,
+            lang="es",
+            subject="Bienvenido",
+            message="Bienvenido a nuestro sitio. Nos alegra verte.",
+        )
 
     def _create_template(self):
         return MailTemplate.objects.create(


### PR DESCRIPTION
### What does this do

Change `_get_message` and `_get_message_with_base` to also allow the use of a parameterizable `base_template`.

### Why are we doing this

[PLAT-41](https://datamindedsolutions.atlassian.net/browse/PLAT-41)

### How should this be tested

Inside the Docker: `python3 demo/manage.py test dbmail`